### PR TITLE
fix: ensure whisper formdata is available

### DIFF
--- a/api/whisper.js
+++ b/api/whisper.js
@@ -2,7 +2,7 @@
 // Vercel / Node runtime. Przyjmuje audio/webm z przeglądarki i przepuszcza do OpenAI Whisper.
 // Env: OPENAI_API_KEY (ustaw w Vercel → Settings → Environment Variables)
 
-import fetch from 'node-fetch';
+import fetch, { Blob, FormData } from 'node-fetch';
 
 export const config = { api: { bodyParser: false } };
 


### PR DESCRIPTION
## Opis
- dodano importy FormData i Blob z node-fetch w endpointzie Whisper, aby środowisko Node miało dostęp do API formularzy
- bez tego serwer rzucał wyjątek i nie przekazywał nagrania do OpenAI

## Checklista
- [x] npm ci
- [x] npm run lint --if-present
- [x] npm run build --if-present
- [x] npm test --if-present

------
https://chatgpt.com/codex/tasks/task_e_68cd12e78808832eb55de323a335d5c0